### PR TITLE
Allow file paths as cl arguments in testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "generate-api": "openapi-forge forge ./example/petstore.json . -o ./example",
-    "test": "dotnet test ./tests/FeaturesTests/FeaturesTests.csproj"
+    "test": "node test"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const shell = require("shelljs");
+
+// Extract cl arguments
+const clArgs = process.argv.slice(2);
+
+// Retrieve the path to feature paths from cl arguments of 'npm test', use default value if none given
+featurePath = clArgs[0] || "..\\..\\..\\openapi-forge\\features\\\*.feature";
+
+const originalFile = fs.readFileSync("./tests/FeaturesTests/FeaturesTests.csproj", "utf-8");
+
+// Replace file path to .feature files in .csproj file
+fs.writeFileSync("./tests/FeaturesTests/FeaturesTests.csproj", originalFile.replace("FEATURE_PATH", featurePath));
+
+shell.exec(`dotnet test ./tests/FeaturesTests/FeaturesTests.csproj`);
+
+// Revert .csproj file back
+fs.writeFileSync("./tests/FeaturesTests/FeaturesTests.csproj", originalFile);

--- a/test.js
+++ b/test.js
@@ -5,14 +5,16 @@ const shell = require("shelljs");
 const clArgs = process.argv.slice(2);
 
 // Retrieve the path to feature paths from cl arguments of 'npm test', use default value if none given
-featurePath = clArgs[0] || "..\\..\\..\\openapi-forge\\features\\\*.feature";
+const featurePath = clArgs[0] || "..\\..\\..\\openapi-forge\\features\\\*.feature";
 
-const originalFile = fs.readFileSync("./tests/FeaturesTests/FeaturesTests.csproj", "utf-8");
+const projectPath = "./tests/FeaturesTests/FeaturesTests.csproj";
 
-// Replace file path to .feature files in .csproj file
-fs.writeFileSync("./tests/FeaturesTests/FeaturesTests.csproj", originalFile.replace("FEATURE_PATH", featurePath));
+const originalFile = fs.readFileSync(projectPath, "utf-8");
 
-shell.exec(`dotnet test ./tests/FeaturesTests/FeaturesTests.csproj`);
+// Replace file path to .feature files in .csproj file, use handlebars style to help make the search value unique
+fs.writeFileSync(projectPath, originalFile.replace("{{FEATURE_PATH}}", featurePath));
 
-// Revert .csproj file back
-fs.writeFileSync("./tests/FeaturesTests/FeaturesTests.csproj", originalFile);
+shell.exec(`dotnet test ${projectPath}`);
+
+// Revert .csproj file back to original
+fs.writeFileSync(projectPath, originalFile);

--- a/tests/FeaturesTests/FeaturesTests.csproj
+++ b/tests/FeaturesTests/FeaturesTests.csproj
@@ -26,7 +26,7 @@
 
     <!-- Copy Feature files into build dir so  Xunit.Gherkin.Quick can discover them-->
     <ItemGroup>
-        <FeatureFiles Include="$(ProjectDir)..\..\node_modules\openapi-forge\features\*.feature" />
+        <FeatureFiles Include="$(ProjectDir){{FEATURE_PATH}}" />
     </ItemGroup>
     <Target Name="PreBuild" AfterTargets="PreBuildEvent">
         <Copy SourceFiles="@(FeatureFiles)" DestinationFolder="$(TargetDir)" />


### PR DESCRIPTION
Use a separate .js file for running `npm test`.

This approach allows for the user to add as cl argument a custom location for the .feature files

I decided to complete a string replace on the .csproj file instead of finding a XML->JSON parser. This is because i did not find a healthy package that had the functionality needed. Also it is only completed once and therefore I felt that the overhead of a new package dependency (with its own dependencies) outweighed the benefits.
