### PR TITLE
fix: fix testing

### DIFF
--- a/helpers/createHeaderParamsSnippet.js
+++ b/helpers/createHeaderParamsSnippet.js
@@ -6,10 +6,11 @@ const createHeaderParamsSnippet = (sortedParams) => {
   let headerSnippet = "";
 
   //Add cookie parameters
-  const cookieParams = getParametersByType(sortedParams, "cookie");
+  let cookieParams = getParametersByType(sortedParams, "cookie");
   if (cookieParams.length !== 0) {
     let safeParamName = toParamName(cookieParams[0].name);
     headerSnippet += `request.Headers.Add("cookie", $"${cookieParams[0].name}={${safeParamName}}`;
+    cookieParams = cookieParams.slice(1);
     for (const cookieParam of cookieParams) {
       safeParamName = toParamName(cookieParam.name);
       headerSnippet += `;${cookieParam.name}={${safeParamName}}`;

--- a/helpers/createQueryStringSnippet.js
+++ b/helpers/createQueryStringSnippet.js
@@ -16,7 +16,7 @@ const serialiseArrayParam = (param) => {
   const safeParamName = toParamName(param.name);
   const serialisedParam = `{string.Join("&", ${safeParamName}.Select(p => $"${
     param.name
-  }={${isStringArrayParam(param) ? "Uri.EscapeDataString(p)" : "p"}}"))}`;
+  }={${isStringArrayParam(param) ? "HttpUtility.UrlEncode(p)" : "p"}}"))}`;
 
   return `if(${safeParamName} != null && ${safeParamName}.Length > 0)
 { ${prefixSerialisedQueryParam(serialisedParam)} }`;
@@ -27,7 +27,7 @@ const serialiseObjectParam = (param) => {
   let serialisedObject = "";
   for (const [propName, objProp] of Object.entries(param.schema.properties)) {
     let serialisedParam = isStringType(objProp)
-      ? `{(${safeParamName}.${propName} == null ? string.Empty : "${propName}=" + Uri.EscapeDataString(${safeParamName}.${propName}))}`
+      ? `{(${safeParamName}.${propName} == null ? string.Empty : "${propName}=" + HttpUtility.UrlEncode(${safeParamName}.${propName}))}`
       : `${propName}={${safeParamName}.${propName}}`;
 
     serialisedObject += serialisedParam + "&";
@@ -40,7 +40,7 @@ const serialiseObjectParam = (param) => {
 const serialisePrimitive = (param) => {
   const safeParamName = toParamName(param.name);
   const escaped = isStringType(param.schema)
-    ? `Uri.EscapeDataString(${safeParamName})`
+    ? `HttpUtility.UrlEncode(${safeParamName})`
     : safeParamName;
 
   const serialisedParam = prefixSerialisedQueryParam(

--- a/helpers/pathContentTypeSupported.js
+++ b/helpers/pathContentTypeSupported.js
@@ -3,14 +3,15 @@ const arrayCount = supportedTypes.length - 1;
 
 const pathContentTypeSupported = (path) => {
   if (path.requestBody) {
-    for (let i = 0; i <= arrayCount; i++) {
-      if (path.requestBody.content) {
+    if (path.requestBody.content) {
+      for (let i = 0; i <= arrayCount; i++) {
         if (path.requestBody.content[supportedTypes[i]]) {
           return true;
         } else {
           continue;
         }
       }
+      return false;
     }
     return false;
   }
@@ -42,6 +43,7 @@ const pathContentTypeSupported = (path) => {
         return true;
       }
     }
+    return false;
   }
   return true;
 };

--- a/helpers/pathContentTypeSupported.js
+++ b/helpers/pathContentTypeSupported.js
@@ -2,21 +2,21 @@ const supportedTypes = ["application/json", "text/plain"];
 const arrayCount = supportedTypes.length - 1;
 
 const pathContentTypeSupported = (path) => {
-  for (let i = 0; i <= arrayCount; i++) {
-    if (path.requestBody) {
+  if (path.requestBody) {
+    for (let i = 0; i <= arrayCount; i++) {
       if (path.requestBody.content) {
         if (path.requestBody.content[supportedTypes[i]]) {
           return true;
-        } else if (i === arrayCount) {
-          return false;
         } else {
           continue;
         }
       }
-      return false;
     }
+    return false;
+  }
 
-    if (path.responses) {
+  if (path.responses) {
+    for (let i = 0; i <= arrayCount; i++) {
       if (
         Object.entries(path.responses).some(
           (entry) =>
@@ -41,16 +41,9 @@ const pathContentTypeSupported = (path) => {
       ) {
         return true;
       }
-
-      if (i === arrayCount) {
-        return false;
-      } else {
-        continue;
-      }
     }
-
-    return true;
   }
+  return true;
 };
 
 module.exports = pathContentTypeSupported;

--- a/helpers/pathContentTypeSupported.js
+++ b/helpers/pathContentTypeSupported.js
@@ -7,11 +7,8 @@ const pathContentTypeSupported = (path) => {
       for (let i = 0; i <= arrayCount; i++) {
         if (path.requestBody.content[supportedTypes[i]]) {
           return true;
-        } else {
-          continue;
         }
       }
-      return false;
     }
     return false;
   }

--- a/helpers/setPathParameters.js
+++ b/helpers/setPathParameters.js
@@ -21,15 +21,15 @@ const setPathParameters = (path, sortedParams) => {
       const safeParamName = toParamName(captureGroup);
       switch (pathParam.schema.type) {
         case "array":
-          return `{string.Join(",", ${safeParamName})}`;
+          return `{string.Join("%2C", ${safeParamName})}`;
         case "object": {
           let serialisedObject = "";
           for (const [propName] of Object.entries(
             pathParam.schema.properties
           )) {
-            serialisedObject += `${propName},{${safeParamName}.${propName}},`;
+            serialisedObject += `${propName}%2C{${safeParamName}.${propName}}%2C`;
           }
-          return serialisedObject.slice(0, -1);
+          return serialisedObject.slice(0, -3);
         }
         default:
           return `{${safeParamName}}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "eslint": "^8.24.0",
         "handlebars": "^4.7.7",
-        "openapi-forge": "github:scottlogic/openapi-forge#6be3962bc263948237f71689b2df7ba73e116a55",
+        "openapi-forge": "github:scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
         "path": "^0.12.7"
       }
     },
@@ -1456,8 +1456,8 @@
     },
     "node_modules/openapi-forge": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/scottlogic/openapi-forge.git#6be3962bc263948237f71689b2df7ba73e116a55",
-      "integrity": "sha512-mQGRevVzlS02euxKe5UZvyESdvlqPaAyBnfOPZW2zVRXfSX/X0Sre8IEOF/q3Q4FbgwbiuLn08hEX47KjXvZFA==",
+      "resolved": "git+ssh://git@github.com/scottlogic/openapi-forge.git#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
+      "integrity": "sha512-14909dV6NcBU4ZZr2ExPUDDHtNlkQg0fG0hg4hySG8N2QoHysdCo8aWa223Recyo6suvV23sK1F67GeWzE22yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1466,7 +1466,7 @@
         "handlebars": "^4.7.7",
         "minimatch": "^5.1.0",
         "node-fetch": "^2.6.7",
-        "prettier": "^2.6.2",
+        "prettier": "^2.7.1",
         "shelljs": "^0.8.5",
         "swagger2openapi": "^7.0.8",
         "yaml": "^2.1.1"
@@ -3341,17 +3341,17 @@
       }
     },
     "openapi-forge": {
-      "version": "git+ssh://git@github.com/scottlogic/openapi-forge.git#6be3962bc263948237f71689b2df7ba73e116a55",
-      "integrity": "sha512-mQGRevVzlS02euxKe5UZvyESdvlqPaAyBnfOPZW2zVRXfSX/X0Sre8IEOF/q3Q4FbgwbiuLn08hEX47KjXvZFA==",
+      "version": "git+ssh://git@github.com/scottlogic/openapi-forge.git#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
+      "integrity": "sha512-14909dV6NcBU4ZZr2ExPUDDHtNlkQg0fG0hg4hySG8N2QoHysdCo8aWa223Recyo6suvV23sK1F67GeWzE22yw==",
       "dev": true,
-      "from": "openapi-forge@github:scottlogic/openapi-forge#6be3962bc263948237f71689b2df7ba73e116a55",
+      "from": "openapi-forge@github:scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
       "requires": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "commander": "^9.2.0",
         "handlebars": "^4.7.7",
         "minimatch": "^5.1.0",
         "node-fetch": "^2.6.7",
-        "prettier": "^2.6.2",
+        "prettier": "^2.7.1",
         "shelljs": "^0.8.5",
         "swagger2openapi": "^7.0.8",
         "yaml": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
+    "openapi-forge": "github:jhowlett-scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
     "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:jhowlett-scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
+    "openapi-forge": "github:jhowlett-scottlogic/openapi-forge#29d19f2184159872889b7709e642f5b7153a4c3b",
     "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:jhowlett-scottlogic/openapi-forge#2d092bed25fec89e1b54cf59a03cf621bf9d1125",
+    "openapi-forge": "github:scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
     "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:scottlogic/openapi-forge#f8eb6a406eab6c2d1c0dc910fe9622f4184cbb44",
+    "openapi-forge": "github:scottlogic/openapi-forge#2d092bed25fec89e1b54cf59a03cf621bf9d1125",
     "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:scottlogic/openapi-forge#4aecbe5d8f47369ed13f1e2315a4999d78cd00cb",
+    "openapi-forge": "github:scottlogic/openapi-forge#2d092bed25fec89e1b54cf59a03cf621bf9d1125",
     "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
+    "openapi-forge": "github:scottlogic/openapi-forge#f8eb6a406eab6c2d1c0dc910fe9622f4184cbb44",
     "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:jhowlett-scottlogic/openapi-forge#29d19f2184159872889b7709e642f5b7153a4c3b",
+    "openapi-forge": "github:jhowlett-scottlogic/openapi-forge#2d092bed25fec89e1b54cf59a03cf621bf9d1125",
     "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:scottlogic/openapi-forge#2d092bed25fec89e1b54cf59a03cf621bf9d1125",
+    "openapi-forge": "github:scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
     "path": "^0.12.7"
   }
 }

--- a/template/ApiClient.cs.handlebars
+++ b/template/ApiClient.cs.handlebars
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using System.Web;
 
 {{>namespace info.title}}
     {{#if info.title}}

--- a/template/Info.cs.handlebars
+++ b/template/Info.cs.handlebars
@@ -7,7 +7,7 @@ using System.Text;
   public static class Info 
   {
     {{#each _info}}
-    public {{#if (isObj this) }}{{capitalizeFirst @key}}{{else}}String{{/if}} {{capitalizeFirst @key}} { get;set; }=  
+    public static {{#if (isObj this) }}{{capitalizeFirst @key}}{{else}}String{{/if}} {{capitalizeFirst @key}} { get;set; }=  
     {{#if (isObj this) }}
       new {{capitalizeFirst @key}} {
     {{#each this}}

--- a/tests/FeaturesTests/Objects.cs
+++ b/tests/FeaturesTests/Objects.cs
@@ -34,21 +34,20 @@ namespace Features
             Assert.Equal(propValue, propInfo.GetValue(_actual).ToString());
         }
 
-        [When(@"calling the method (\w+) with (?:object|array|parameters) ""(.+)""")]
-        public async Task CallMethodWithParameters(string methodName, string jsonTextObect)
+        [When(@"calling the method (\w+) with (?:object|array|parameters) (.+)")]
+        public async Task CallMethodWithParameters(string methodName, string jsonTextObject)
         {
-            var inlineObj = _testHelper.JsonToTypeInstance("InlineObject1", jsonTextObect);
+            var inlineObj = _testHelper.JsonToTypeInstance("InlineObject1", jsonTextObject);
 
             await CallMethod(methodName, new object[] { inlineObj });
         }
 
-        [And("the request should have a body with value \"(.+)\"")]
+        [And("the request should have a body with value (.+)")]
         public async Task CheckRequestBody(string propValue)
         {
             Assert.NotNull(_request);
             var body = await _request.Content.ReadAsStringAsync();
             Assert.NotNull(body);
-            body = body.Replace("\"", "'");
             Assert.Equal(propValue, body);
         }
     }

--- a/tests/FeaturesTests/PathParams.cs
+++ b/tests/FeaturesTests/PathParams.cs
@@ -14,15 +14,22 @@ namespace Features
         {
         }
 
-        [When(@"calling the method (\w+) with (object|array|parameters) ""(.+)""")]
+        [When(@"calling the method (\w+) with (parameters|array) ""(.+)""")]
         public async Task CallMethodWithStringParameters(string methodName, string paramType, string parametersString)
         {
             var parameters = paramType switch
             {
-                "object" => new object[] { _testHelper.JsonToTypeInstance("InlineObject1", parametersString) },
                 "array" => new object[] { parametersString.Split(",") },
                 _ => parametersString.Split(",")
             };
+
+            await CallMethod(methodName, parameters);
+        }
+
+        [When(@"calling the method (\w+) with object (.+)")]
+        public async Task CallMethodWithStringObject(string methodName, string parametersString)
+        {
+            var parameters = new object[] { _testHelper.JsonToTypeInstance("InlineObject1", parametersString) };
 
             await CallMethod(methodName, parameters);
         }

--- a/tests/FeaturesTests/QueryString.cs
+++ b/tests/FeaturesTests/QueryString.cs
@@ -12,15 +12,22 @@ namespace Features
         {
         }
 
-        [When(@"calling the method (\w+) with (object|array|parameters) ""(.+)""")]
+        [When(@"calling the method (\w+) with (array|parameters) ""(.+)""")]
         public async Task CallMethodWithStringParameters(string methodName, string paramType, string parametersString)
         {
             var parameters = paramType switch
             {
-                "object" => new object[] { _testHelper.JsonToTypeInstance("InlineObject1", parametersString) },
                 "array" => new object[] { parametersString.Split(",") },
                 _ => parametersString.Split(",")
             };
+
+            await CallMethod(methodName, parameters);
+        }
+
+        [When(@"calling the method (\w+) with object (.+)")]
+        public async Task CallMethodWithStringObject(string methodName, string parametersString)
+        {
+            var parameters = new object[] { _testHelper.JsonToTypeInstance("InlineObject1", parametersString) };
 
             await CallMethod(methodName, parameters);
         }

--- a/tests/FeaturesTests/RequestBody.cs
+++ b/tests/FeaturesTests/RequestBody.cs
@@ -15,7 +15,7 @@ namespace Features
         }
 
 
-        [When(@"calling the method (\w+) with (?:object|array|parameters) ""(.+)""")]
+        [When(@"calling the method (\w+) with (?:object|array|parameters) (.+)")]
         public async Task CallMethodWithStringParameters(string methodName, string parametersString)
         {
             var inlineObj = _testHelper.JsonToTypeInstance("ObjectResponse", parametersString);
@@ -23,13 +23,12 @@ namespace Features
             await CallMethod(methodName, new object[] { inlineObj });
         }
 
-        [And(@"the request should have a body with value ""(.+)""")]
+        [And(@"the request should have a body with value (.+)")]
         public async Task CheckRequestBody(string propValue)
         {
             Assert.NotNull(_request);
             var body = await _request.Content.ReadAsStringAsync();
             Assert.NotNull(body);
-            body = body.Replace("\"", "'");
             Assert.Equal(propValue, body);
         }
     }

--- a/tests/FeaturesTests/Response.cs
+++ b/tests/FeaturesTests/Response.cs
@@ -55,7 +55,7 @@ namespace Features
             Assert.Equal(propValue, propInfo.GetValue(_actual).ToString());
         }
 
-        [When(@"calling the method (\w+) with parameters ""(.+)""")]
+        [When(@"calling the method (\w+) with parameters (.+)")]
         public async Task CallMethodWithParameters(string methodName, string rawParameters)
         {
             var paramStringValues = rawParameters.Split(",");

--- a/tests/FeaturesTests/TestHelper.cs
+++ b/tests/FeaturesTests/TestHelper.cs
@@ -49,7 +49,7 @@ namespace Features
 
         private void ForgeApi()
         {
-            RunCmdPrompt($"openapi-forge forge {_schemaFilePath} {Constants.TemplateProjectPath} -o {_outputPath} -s -l v ");
+            RunCmdPrompt($"openapi-forge forge {_schemaFilePath} {Constants.TemplateProjectPath} -o {_outputPath} -s");
         }
 
         private void GetApiClientTypes()
@@ -153,11 +153,6 @@ namespace Features
 
             using var errorReader = cmd.StandardError;
             var errorOutput = errorReader.ReadToEnd();
-
-            using var outReader = cmd.StandardOutput;
-            var outOutput = outReader.ReadToEnd();
-
-            Console.WriteLine(outOutput);
 
             Assert.Equal(string.Empty, errorOutput);
         }

--- a/tests/FeaturesTests/TestHelper.cs
+++ b/tests/FeaturesTests/TestHelper.cs
@@ -154,6 +154,11 @@ namespace Features
             using var errorReader = cmd.StandardError;
             var errorOutput = errorReader.ReadToEnd();
 
+            using var outReader = cmd.StandardOutput;
+            var outOutput = outReader.ReadToEnd();
+
+            Console.WriteLine(outOutput);
+
             Assert.Equal(string.Empty, errorOutput);
         }
     }

--- a/tests/FeaturesTests/TestHelper.cs
+++ b/tests/FeaturesTests/TestHelper.cs
@@ -49,7 +49,7 @@ namespace Features
 
         private void ForgeApi()
         {
-            RunCmdPrompt($"openapi-forge forge {_schemaFilePath} {Constants.TemplateProjectPath} -o {_outputPath} -s -l v");
+            RunCmdPrompt($"openapi-forge forge {_schemaFilePath} {Constants.TemplateProjectPath} -o {_outputPath} -s -l v ");
         }
 
         private void GetApiClientTypes()

--- a/tests/FeaturesTests/TestHelper.cs
+++ b/tests/FeaturesTests/TestHelper.cs
@@ -49,7 +49,7 @@ namespace Features
 
         private void ForgeApi()
         {
-            RunCmdPrompt($"openapi-forge forge {_schemaFilePath} {Constants.TemplateProjectPath} -o {_outputPath} -s");
+            RunCmdPrompt($"openapi-forge forge {_schemaFilePath} {Constants.TemplateProjectPath} -o {_outputPath} -s -l v");
         }
 
         private void GetApiClientTypes()


### PR DESCRIPTION
add missing step definitions
use HttpUtility.UrlEncode for encoding URI arguments as it correctly encodes spaces.
use encoded form of commas for URI arguments
fix for-loop double first element bug