### PR TITLE
fix: fix verb tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^8.24.0",
     "handlebars": "^4.7.7",
-    "openapi-forge": "github:scottlogic/openapi-forge#b667ab7c3e53d3ba5563faf2f8b21ec6a6e4d5d1",
+    "openapi-forge": "github:scottlogic/openapi-forge#1f3af317a126062b10958d4e12eb2d620a1ea61f",
     "path": "^0.12.7"
   }
 }

--- a/tests/FeaturesTests/HTTPVerbs.cs
+++ b/tests/FeaturesTests/HTTPVerbs.cs
@@ -15,7 +15,7 @@ namespace Features
         {
         }
 
-        [When(@"calling the(?: spied?) method (\w+) without params")]
+        [When(@"calling the(?: spied)? method (\w+) without params")]
         public async Task
         CallWithoutParameters(string methodName)
         {

--- a/tests/FeaturesTests/HTTPVerbs.cs
+++ b/tests/FeaturesTests/HTTPVerbs.cs
@@ -15,7 +15,7 @@ namespace Features
         {
         }
 
-        [When(@"calling the spied method (\w+) without params")]
+        [When(@"calling the(?: spied?) method (\w+) without params")]
         public async Task
         CallWithoutParameters(string methodName)
         {


### PR DESCRIPTION
Tests were failing due to change of index of method group due to new group added in `calling the spied method (\w+) without params` 

Solution: use a non-capturing group to not allow group to be a argument in method. Also moved ? to target whole group not the 'd' from spied