### PR TITLE
fix: use global forge when testing

### DIFF
--- a/tests/FeaturesTests/TestHelper.cs
+++ b/tests/FeaturesTests/TestHelper.cs
@@ -11,6 +11,8 @@ namespace Features
 
         private readonly string _schemaFilePath;
 
+        private readonly string _currentDirectory;
+
         private readonly string _testId;
 
         private Type _configurationType;
@@ -22,8 +24,9 @@ namespace Features
         public TestHelper(string testId)
         {
             _testId = testId;
-            _outputPath = $"./generated-tests/{testId}";
+            _outputPath = $"generated-tests/{testId}";
             _schemaFilePath = $"{_outputPath}/schema.json";
+            _currentDirectory = Directory.GetCurrentDirectory();
         }
 
         public void GenerateApi(string schema)
@@ -49,7 +52,7 @@ namespace Features
 
         private void ForgeApi()
         {
-            RunCmdPrompt($"openapi-forge forge {_schemaFilePath} {Constants.TemplateProjectPath} -o {_outputPath}");
+            RunCmdPrompt($"cd ../../../../../../ && npx openapi-forge forge {_currentDirectory}/{_schemaFilePath} {_currentDirectory}/{Constants.TemplateProjectPath} -o {_currentDirectory}/{_outputPath} -l v");
         }
 
         private void GetApiClientTypes()


### PR DESCRIPTION
When testing the generator it now uses the global version of the forge. This now means that both the typescript and csharp generator have the same behaviour.

This still needs to be tested on linux. I am guessing it will need some tweaks.

Also this work has highlighted an issue that is:
Testing uses global version of forge but local version of feature files.
Moving forward we either just use the global version to remove the forge dependency in the generators or have a flag in the test command of each generator that allows the user to choose between local or global forge. 