### PR TITLE
feat: allow the specification of a namespace via the generator options

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "namespace": {
+    "default": "OpenApiForge",
+    "description": "The namespace for the generated classes."
+  }
+}

--- a/partials/namespace.handlebars
+++ b/partials/namespace.handlebars
@@ -1,1 +1,1 @@
-{{#if infoTitle}}namespace {{toClassName infoTitle}}{{else}}namespace OpenApiForge{{/if}}
+namespace {{_options.[generator.namespace]}}

--- a/template/ApiClient.cs.handlebars
+++ b/template/ApiClient.cs.handlebars
@@ -15,7 +15,7 @@ using System.Web;
 /// </summary>
 {{#if info.description}}{{docComment info.description}}{{/if}}
 {{#if info.version}}/// <version>{{info.version}}</version>{{/if}}
-{{>namespace info.title}} {
+{{>namespace}} {
     
     public class ApiClient{{_tag.name}}  : IApiClient{{_tag.name}}
     {

--- a/template/ApiModel.cs.handlebars
+++ b/template/ApiModel.cs.handlebars
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-{{>namespace info.title}} {
+{{>namespace}} {
 
 {{#each components.schemas}}
 {{> model}}

--- a/template/Configuration.cs.handlebars
+++ b/template/Configuration.cs.handlebars
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-{{>namespace info.title}} {
+{{>namespace}} {
 
   public class Configuration 
   {

--- a/template/IApiClient.cs.handlebars
+++ b/template/IApiClient.cs.handlebars
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 /// </summary>
 {{#if info.description}}{{docComment info.description}}{{/if}}
 {{#if info.version}}/// <version>{{info.version}}</version>{{/if}}
-{{>namespace info.title}} {
+{{>namespace}} {
 
     public interface IApiClient{{_tag.name}}
     {

--- a/template/Info.cs.handlebars
+++ b/template/Info.cs.handlebars
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-{{>namespace info.title}} {
+{{>namespace}} {
 
   public static class Info 
   {

--- a/template/Startup.cs.handlebars
+++ b/template/Startup.cs.handlebars
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 
-{{>namespace info.title}} {
+{{>namespace}} {
  
     public static class Startup
     {


### PR DESCRIPTION
NOTE: the tests for this change will not pass until the following PR is merged:

https://github.com/ScottLogic/openapi-forge/pull/166

The C# tests use the globally installed `openapi-forge` command to generate the API, which is a notable difference to the TS / JS implementations. Probably worth considering when tackling this issue: https://github.com/ScottLogic/openapi-forge/issues/158